### PR TITLE
s21e update ready for release.

### DIFF
--- a/hw/convoy/s21e/anduril.h
+++ b/hw/convoy/s21e/anduril.h
@@ -64,23 +64,16 @@
 
 #define USE_SIMPLE_UI_RAMPING_TOGGLE
 
-//reboot bug if blink on button so don't enable changing it from main
-//#define DEFAULT_BLINK_CHANNEL  CM_MAIN
-
-//does not look good on this driver and takes alot of space
-//#define USE_SMOOTH_STEPS
+#define USE_SMOOTH_STEPS
 
 #define USE_EXTRA_BATTCHECK_DIGIT
 
-#define USE_SOFT_FACTORY_RESET
 
 // too big, turn off extra features
-#undef USE_TACTICAL_MODE
-//#undef USE_MOMENTARY_MODE
 #undef USE_SOS_MODE
 #undef USE_BEACON_MODE
-//#undef USE_VERSION_CHECK
-
+#undef USE_VERSION_CHECK
+#undef USE_RAMP_SPEED_CONFIG
 
 
 //blinkies

--- a/hw/convoy/s21e/anduril.h
+++ b/hw/convoy/s21e/anduril.h
@@ -49,17 +49,10 @@
 
 #define DEFAULT_2C_STYLE 1  // enable 2 click turbo (Anduril 1 style)
 
-#define USE_VERSION_CHECK
 // don't blink while ramping
-#ifdef BLINK_AT_RAMP_FLOOR
-#undef BLINK_AT_RAMP_FLOOR
-#endif
-#ifdef BLINK_AT_RAMP_MIDDLE
-#undef BLINK_AT_RAMP_MIDDLE
-#endif
-#ifdef BLINK_AT_RAMP_CEIL
 #undef BLINK_AT_RAMP_CEIL
-#endif
+#undef BLINK_AT_RAMP_MIDDLE
+#undef BLINK_AT_RAMP_FLOOR
 
 
 #define USE_SIMPLE_UI_RAMPING_TOGGLE

--- a/hw/convoy/s21e/hwdef.h
+++ b/hw/convoy/s21e/hwdef.h
@@ -21,10 +21,9 @@
 
 // channel modes
 // * 0. FET+7135 stacked
-#define NUM_CHANNEL_MODES  2
+#define NUM_CHANNEL_MODES  1
 enum CHANNEL_MODES {
     CM_MAIN = 0,
-    CM_AUX
 };
 
 #define DEFAULT_CHANNEL_MODE  CM_MAIN


### PR DESCRIPTION
remove aux channel, its bugged anyway, saves space to enable more features, like smooth steps, tac mode.

-removed ramp speed config (its too slow anyways)